### PR TITLE
Fix vorg folding of non-vorg files

### DIFF
--- a/ftplugin/vorg.vim
+++ b/ftplugin/vorg.vim
@@ -23,7 +23,7 @@ nmap <buffer> == ma0t]rx`a
 nmap <buffer> -- ma0t]r `a
 
 " shortcut for adding tags at the end of an item
-imap ` <right><right><space><><left>
+imap <buffer> ` <right><right><space><><left>
 
 " Shift lines up and down
 nnoremap <buffer> <C-j> mz:m+<CR>`z
@@ -37,7 +37,7 @@ vnoremap <buffer> <C-k> :m'<-2<CR>gv=`>my`<mzgv`yo`z
 nnoremap <buffer> <C-t> :/-.*\<.*.*\><LEFT><LEFT><LEFT>
 nnoremap <buffer> <C-o> :/[-\*]\ *\[\ \].*@
 
-" shortcuts for date entry 
+" shortcuts for date entry
 ab <buffer> dd <C-R>=strftime("%Y-%m-%d")<CR>
 ab <buffer> dt <C-R>=strftime("%Y-%m-%d @ %H:%M")<CR>
 ab <buffer> -0 - <C-R>=strftime("%Y-%m-%d @ %H:%M")<CR> \|

--- a/syntax/vorg.vim
+++ b/syntax/vorg.vim
@@ -44,7 +44,7 @@ hi! link Folded Comment
 function! SimpleFoldText()
 	return	repeat(' ',indent(v:foldstart)).substitute(getline(v:foldstart),"[ \t]*[-\*]","+","").' '
 endfunction
-set foldtext=SimpleFoldText() " Custom fold text function
+setlocal foldtext=SimpleFoldText() " Custom fold text function
 
 function! LimitFoldLevel(level)
 	return a:level
@@ -84,7 +84,7 @@ function! VorgFoldExpr(lnum)
    return '='
 endfunction
 
-set foldmethod=expr
-set foldexpr=VorgFoldExpr(v:lnum)
+setlocal foldmethod=expr
+setlocal foldexpr=VorgFoldExpr(v:lnum)
 
 let b:current_syntax = "vorg"


### PR DESCRIPTION
After opening a vorg file, opening any other file causes it to be folded in a vorg manner. Replacing sets with setlocals in syntax seems to fix it